### PR TITLE
Run restart handler in serial

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
     name: etcd
     daemon_reload: yes
     state: restarted
+  delegate_to: "{{ item }}"
+  with_items:
+    - "{{ groups[etcd_hosts_group] }}"
+  run_once: True


### PR DESCRIPTION
When upgrading versions of etcd3 (for e.g. from the current default to v
3.3.0) the services need to be restarted in serial. This ensures that
the cluster doesn't fail to restart properly.

This can be achieved by delegating to other hosts, from the first host
that calls the handler.